### PR TITLE
RUN-4064: Update aiohttp for CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-storage-blob>=12.17.0
 python-magic>=0.4.27
 
 # HTTP client for async operations
-aiohttp>=3.8.5
+aiohttp>=3.13.3
 
 # CVE-2025-66471 / CVE-2025-66418
 urllib3>=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ python-magic>=0.4.27
 aiohttp>=3.13.3
 
 # CVE-2025-66471 / CVE-2025-66418
-urllib3>=2.6.0
+urllib3>=2.6.3
 
 # Additional security considerations:
 # - Use virtual environments to isolate dependencies


### PR DESCRIPTION
Bump aiohttp to 3.13.3 minimum for:
CVE-2025-69223
CVE-2025-69227
CVE-2025-69228