### PR TITLE
RUN-4114: Fix CVE-2026-21226 - azure-core Deserialization of Untrusted Data vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@
 # Azure Storage SDK
 azure-storage-blob>=12.17.0
 
+# CVE-2026-21226 - Deserialization of untrusted data in azure-core
+azure-core>=1.38.0
+
 # File type detection
 python-magic>=0.4.27
 


### PR DESCRIPTION
**Summary**
Fixes CVE-2026-21226, a Deserialization of Untrusted Data vulnerability in azure-core that allows an authorized attacker to execute code over a network.
**Details**

- Vulnerability: CVE-2026-21226 (CVSS 7.5 HIGH)
- Affected package: azure-core &lt; 1.38.0
- Dependency path: azure-storage-blob → azure-core
- Fix: Pin azure-core to version 1.38.0 or higher in requirements.txt

**Changes**
Added azure-core>=1.38.0 to requirements.txt to ensure the patched version is installed
